### PR TITLE
Initial modifications to support py2neo 2.x

### DIFF
--- a/neomodel/contrib/semi_structured.py
+++ b/neomodel/contrib/semi_structured.py
@@ -52,17 +52,17 @@ class SemiStructuredNode(StructuredNode):
     def inflate(cls, node):
         props = {}
         for key, prop in cls.defined_properties(aliases=False, rels=False).items():
-            if key in node._properties:
-                props[key] = prop.inflate(node._properties[key])
+            if key in node.properties:
+                props[key] = prop.inflate(node.properties[key])
             elif prop.has_default:
                 props[key] = prop.default_value()
             else:
                 props[key] = None
         # handle properties not defined on the class
-        for free_key in [key for key in node._properties if key not in props]:
+        for free_key in [key for key in node.properties if key not in props]:
             if hasattr(cls, free_key):
-                raise InflateConflict(cls, free_key, node._properties[free_key], node._id)
-            props[free_key] = node._properties[free_key]
+                raise InflateConflict(cls, free_key, node.properties[free_key], node._id)
+            props[free_key] = node.properties[free_key]
 
         snode = cls(**props)
         snode._id = node._id

--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -106,14 +106,14 @@ class StructuredNode(NodeBase):
             # update
             query = "START self=node({self})\n"
             query += "\n".join(["SET self.{} = {{{}}}".format(key, key) + "\n"
-                for key in self.__properties__.keys()])
+                                for key in self.__properties__.keys()])
             for label in self.inherited_labels():
                 query += "SET self:`{}`\n".format(label)
             params = self.deflate(self.__properties__, self)
             self.cypher(query, params)
         elif hasattr(self, 'deleted') and self.deleted:
             raise ValueError("{}.save() attempted on deleted node".format(self.__class__.__name__))
-        else: # create
+        else:  # create
             self._id = self.create(self.__properties__)[0]._id
         return self
 
@@ -172,8 +172,8 @@ class StructuredNode(NodeBase):
     def inflate(cls, node):
         props = {}
         for key, prop in cls.defined_properties(aliases=False, rels=False).items():
-            if key in node._properties:
-                props[key] = prop.inflate(node._properties[key], node)
+            if key in node.properties:
+                props[key] = prop.inflate(node.properties[key], node)
             elif prop.has_default:
                 props[key] = prop.default_value()
             else:

--- a/neomodel/relationship.py
+++ b/neomodel/relationship.py
@@ -55,14 +55,14 @@ class StructuredRel(StructuredRelBase):
     def inflate(cls, rel):
         props = {}
         for key, prop in cls.defined_properties(aliases=False, rels=False).items():
-            if key in rel._properties:
-                props[key] = prop.inflate(rel._properties[key], obj=rel)
+            if key in rel:
+                props[key] = prop.inflate(rel[key], obj=rel)
             elif prop.has_default:
                 props[key] = prop.default_value()
             else:
                 props[key] = None
         srel = cls(**props)
-        srel._start_node_id = rel._start_node_id
-        srel._end_node_id = rel._end_node_id
+        srel._start_node_id = rel.start_node._id
+        srel._end_node_id = rel.end_node._id
         srel._id = rel._id
         return srel

--- a/neomodel/relationship_manager.py
+++ b/neomodel/relationship_manager.py
@@ -136,7 +136,7 @@ class RelationshipManager(Traversal):
         result, meta = self.source.cypher("START us=node({self}), old=node({old}) MATCH " + old_rel + " RETURN r",
             {'old': old_obj._id})
         if result:
-            existing_properties = result[0][0]._properties.keys()
+            existing_properties = result[0][0].properties.keys()
         else:
             raise NotConnected('reconnect', self.source, old_obj)
 

--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -4,10 +4,15 @@ import time
 import warnings
 import sys
 from threading import local
-from py2neo import neo4j
-from py2neo.exceptions import ClientError
+
+from py2neo import authenticate, Graph, Resource
+from py2neo.cypher import CypherTransaction, CypherResource
+from py2neo.cypher.core import RecordProducer
+from py2neo.packages.httpstream.packages.urimagic import URI
+from py2neo.cypher.error import ClientError
 from py2neo.packages.httpstream import SocketError
-from py2neo import cypher as py2neo_cypher
+from py2neo.util import is_collection
+
 from .exception import CypherException, UniqueProperty, TransactionError
 if sys.version_info >= (3, 0):
     from urllib.parse import urlparse
@@ -16,16 +21,16 @@ else:
 
 logger = logging.getLogger(__name__)
 
-path_to_id = lambda val: int(neo4j.URI(val).path.segments[-1])
+path_to_id = lambda val: int(URI(val).path.segments[-1])
 
 
-class PatchedTransaction(py2neo_cypher.Transaction):
+class PatchedTransaction(CypherTransaction):
     def __init__(self, uri):
         super(PatchedTransaction, self).__init__(uri)
 
     def _post(self, resource):
-        self._assert_unfinished()
-        rs = resource._post({"statements": self._statements})
+        self.__assert_unfinished()
+        rs = resource.post({"statements": self.statements})
         headers = dict(rs.headers)
         location = None
         # when run in python 2 the keys in the header dictionary all start with lowercase letters
@@ -35,12 +40,12 @@ class PatchedTransaction(py2neo_cypher.Transaction):
         elif "Location" in headers:
             location = headers["Location"]
         if location is not None:
-            self._execute = py2neo_cypher.Resource(location)
+            self._execute = Resource(location)
         j = rs.json
         rs.close()
         self._clear()
         if "commit" in j:
-            self._commit = py2neo_cypher.Resource(j["commit"])
+            self._commit = Resource(j["commit"])
         if "errors" in j and len(j['errors']):
             error = j["errors"][0]
             txid = int(j['commit'].split('/')[-2])
@@ -48,7 +53,7 @@ class PatchedTransaction(py2neo_cypher.Transaction):
             raise TransactionError(error['message'], error['code'], trace, txid)
         out = []
         for result in j["results"]:
-            producer = py2neo_cypher.RecordProducer(result["columns"])
+            producer = RecordProducer(result["columns"])
             out.append([
                 producer.produce(_hydrated(r["rest"]))
                 for r in result["data"]
@@ -74,20 +79,20 @@ class Rel(object):
 def _hydrated(data):
     if isinstance(data, dict):
         if 'self' in data:
-            obj_type = neo4j.URI(data['self']).path.segments[-2]
+            obj_type = URI(data['self']).path.segments[-2]
             if obj_type == 'node':
                 return Node(data)
             elif obj_type == 'relationship':
                 return Rel(data)
         raise NotImplemented("Don't know how to inflate: " + repr(data))
-    elif neo4j.is_collection(data):
+    elif is_collection(data):
         return type(data)([_hydrated(datum) for datum in data])
     else:
         return data
 
-neo4j._hydrated = _hydrated
-py2neo_cypher._hydrated = _hydrated
-py2neo_cypher.Transaction = PatchedTransaction
+Graph._hydrated = _hydrated
+CypherResource._hydrated = _hydrated
+CypherTransaction = PatchedTransaction
 
 
 class Database(local):
@@ -100,13 +105,13 @@ class Database(local):
             credentials, self.host = u.netloc.split('@')
             self.user, self.password, = credentials.split(':')
             self.url = ''.join([u.scheme, '://', self.host, u.path, u.query])
-            neo4j.authenticate(self.host, self.user, self.password)
+            authenticate(self.host, self.user, self.password)
         else:
             self.url = _url
 
     def new_session(self):
         try:
-            self.session = neo4j.GraphDatabaseService(self.url)
+            self.session = Graph(self.url)
         except SocketError as e:
             raise SocketError("Error connecting to {0} - {1}".format(self.url, e))
 
@@ -164,7 +169,7 @@ class Database(local):
         if hasattr(self, 'tx_session'):
             raise SystemError("Transaction already in progress")
 
-        self.tx_session = py2neo_cypher.Session(self.url).create_transaction()
+        self.tx_session = self.session.cypher.begin()
 
     def commit(self):
         if not hasattr(self, 'tx_session'):
@@ -184,17 +189,16 @@ class Database(local):
     def _execute_query(self, query, params):
         if hasattr(self, 'tx_session'):
             self.tx_session.append(query, params or {})
-            results = self.tx_session.execute()[0]
+            results = self.tx_session.process()[0]
             if results:
-                return [list(r.values) for r in results], list(results[0].columns)
+                return results, list(results.columns)
             else:
                 return [], None
         else:
             if not hasattr(self, 'session'):
                 self.new_session()
-            cq = neo4j.CypherQuery(self.session, '')
-            result = neo4j.CypherResults(cq._cypher._post({'query': query, 'params': params or {}}))
-            return [list(r.values) for r in result.data], list(result.columns)
+            results = self.session.cypher.execute(query, params)
+            return results, list(results.columns)
 
     def cypher_query(self, query, params=None, handle_unique=True):
         try:
@@ -205,6 +209,9 @@ class Database(local):
             if (handle_unique and e.message and " already exists with label " in e.message
                     and e.message.startswith('Node ')):
                 raise UniqueProperty(e.message)
+
+            if isinstance(e, ClientError):
+                raise e
 
             if isinstance(e, TransactionError):
                 raise CypherException(query, params, e.message, e.java_exception, e.java_trace)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     keywords='graph neo4j py2neo ORM',
     tests_require=['nose==1.1.2'],
     test_suite='nose.collector',
-    install_requires=['py2neo==1.6.4', 'pytz==2014.7'],
+    install_requires=['py2neo==2.0.7', 'pytz==2015.4'],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         'Intended Audience :: Developers',

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -3,5 +3,5 @@ import warnings
 from neomodel.core import db
 warnings.simplefilter('default')
 db.new_session()
-db.session.clear()
+db.session.delete_all()
 print("neo4j version: ", *db.session.neo4j_version)

--- a/test/test_cypher.py
+++ b/test/test_cypher.py
@@ -1,4 +1,5 @@
-from neomodel import StructuredNode, StringProperty, CypherException
+from neomodel import StructuredNode, StringProperty
+from py2neo.cypher.error.statement import InvalidSyntax
 
 
 class User2(StructuredNode):
@@ -24,11 +25,8 @@ def test_cypher_syntax_error():
     jim = User2(email='jim1@test.com').save()
     try:
         jim.cypher("START a=node({self}) RETURN xx")
-    except CypherException as e:
+    except InvalidSyntax as e:
         assert hasattr(e, 'message')
-        assert hasattr(e, 'query')
-        assert hasattr(e, 'query_parameters')
-        assert hasattr(e, 'java_trace')
-        assert hasattr(e, 'java_exception')
+        assert hasattr(e, 'code')
     else:
         assert False


### PR DESCRIPTION
## Overview ##
This PR provides the updates necessary to move towards py2neo 2.x. Functionality remains largely backwards compatible except for the known move from raising a `CypherException` to raising an `InvalidSyntax` when a cypher query has invalid syntax. This provides a more clear indication as to what is going wrong.
 
## Unresolved Issues ##
* Pypy tests are not passing on TravisCI
* Need to transition `START`queries to `MATCH`
* Documentation surrounding Neo4j 2.2.x requirements
  * Information primarily directing users to py2neo's docs on setting a new password for a new db

I believe 2 and 3 in the list above are outside the scope of this PR and should be moved into separate issues. As for pypy support I'm not sure what is causing the issue and am not up on pypy so I was hoping during the review someone could assist in pointing out what needs to be changed to fix the failing tests.