### PR TITLE
CypherException logging TypeError exception

### DIFF
--- a/neomodel/exception.py
+++ b/neomodel/exception.py
@@ -39,10 +39,9 @@ class CypherException(Exception):
         self.query_parameters = params
 
     def __str__(self):
-        trace = "\n    ".join(self.java_trace)
-
         return "\n{0}: {1}\nQuery: {2}\nParams: {3}\nTrace: {4}\n".format(
-            self.java_exception, self.message, self.query, repr(self.query_parameters), trace)
+            self.java_exception, self.message, self.query,
+            repr(self.query_parameters), self.java_trace)
 
 
 class TransactionError(Exception):

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -1,10 +1,13 @@
-from neomodel import StructuredNode, StringProperty, DoesNotExist
+from neomodel import StructuredNode, StringProperty, DoesNotExist, CypherException
 import pickle
 
 
 class Person(StructuredNode):
     name = StringProperty(unique_index=True)
 
+
+def test_cypher_exception_can_be_displayed():
+    print CypherException("SOME QUERY", (), "ERROR", None, None)
 
 def test_object_does_not_exist():
     try:

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -7,7 +7,7 @@ class Person(StructuredNode):
 
 
 def test_cypher_exception_can_be_displayed():
-    print CypherException("SOME QUERY", (), "ERROR", None, None)
+    print(CypherException("SOME QUERY", (), "ERROR", None, None))
 
 def test_object_does_not_exist():
     try:


### PR DESCRIPTION
This commit will fix the previous type error when there was a None type
as java exception.

We have noticed this while running our continuous integration.  When printing the follow exception:
    CypherException: 
    None: None
    Query: CREATE CONSTRAINT on (n:UserNode) ASSERT n.username IS UNIQUE; 
    Params: None
    Trace: None

There was a typeError on 

```python
File "/home/andrefsp/.virtualenvs/depop/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/andrefsp/development/depop/neomodel/test/test_exceptions.py", line 12, in test_cypher_exception
    print CypherException("SOME QUERY", (), "ERROR", None, None)
  File "/home/andrefsp/development/depop/neomodel/neomodel/exception.py", line 42, in __str__
    trace = "\n    ".join(self.java_trace)
TypeError: 
```

This was the solution we used to carry on however I admit this might be just the symptom of the real issue.  
