### PR TITLE
check "order_by" on source and not self

### DIFF
--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -132,7 +132,7 @@ class QueryBuilder(object):
 
             self.build_additional_match(ident, source)
 
-            if hasattr(self.node_set, '_order_by'):
+            if hasattr(source, '_order_by'):
                 self.build_order_by(ident, source)
 
             if source.filters:


### PR DESCRIPTION
when the NodeSet is a "complex" one built on top of a Traversal etc. this call fails as the check is on the self.node_set, when the source is an inner NodeSet.