### PR TITLE
performance enhancements for bulk operations 

### DIFF
--- a/neomodel/properties.py
+++ b/neomodel/properties.py
@@ -21,7 +21,10 @@ class PropertyManager(object):
     """Common stuff for handling properties in nodes and relationships"""
     def __init__(self, *args, **kwargs):
 
-        for key, val in self.defined_properties(rels=False, aliases=False).items():
+        properties = getattr(self, "__all_properties__", None)
+        if properties is None:
+            properties = self.defined_properties(rels=False, aliases=False).items()
+        for key, val in properties:
             # handle default values
             if key not in kwargs or kwargs[key] is None:
                 if hasattr(val, 'has_default') and val.has_default:
@@ -38,8 +41,11 @@ class PropertyManager(object):
             if key in kwargs:
                 del kwargs[key]
 
+        aliases = getattr(self, "__all_aliases__", None)
+        if aliases is None:
+            aliases = self.defined_properties(rels=False, properties=False).items()
         # aliases next so they don't have their alias over written
-        for key, val in self.defined_properties(rels=False, properties=False).items():
+        for key, val in aliases:
             if key in kwargs:
                 setattr(self, key, kwargs[key])
                 del kwargs[key]
@@ -60,7 +66,7 @@ class PropertyManager(object):
         return props
 
     @classmethod
-    def deflate(cls, obj_props, obj=None):
+    def deflate(cls, obj_props, obj=None, skip_empty=False):
         """ deflate dict ready to be stored """
         deflated = {}
         for key, prop in cls.defined_properties(aliases=False, rels=False).items():
@@ -68,9 +74,9 @@ class PropertyManager(object):
                 deflated[key] = prop.deflate(obj_props[key], obj)
             elif prop.has_default:
                 deflated[key] = prop.deflate(prop.default_value(), obj)
-            elif prop.required:
+            elif prop.required or prop.unique_index:
                 raise RequiredProperty(key, cls)
-            else:
+            elif skip_empty is not True:
                 deflated[key] = None
         return deflated
 

--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -228,24 +228,21 @@ class Database(local):
 
         return results
 
-    def cypher_stream_query(self, queries):
+    def cypher_stream_query(self, query, params=None):
         """
-        Streams the provided queries, and generates responses when iterated.
+        Streams the provided query, and generates responses when iterated.
 
-        :param queries:  List of tuples, each with a (cypher query, params)
-        :type queries: list of tuples
+        :param query:  A CYPHER query.
+        :type query: str
+        :param params: optional, key value params to pass into the query.
+        :type params: dict
         :rtype: generator
         """
-        jobs = [CypherJob(query, params) for query, params in queries]
         # make sure thread local session is set
         if not hasattr(self, 'session'):
             self.new_session()
 
-        for r in self.session.batch.stream(jobs):
-            if r.content:
-                yield RecordList.hydrate(r.content, self.session)
-            else:
-                yield None
+        return self.session.cypher.stream(query, params)
 
     def cypher_batch_query(self, queries, handle_unique=True):
         """


### PR DESCRIPTION
**parameterized bulk queries**
utilize passing property maps for MERGE and CREATE queries
see: http://neo4j.com/docs/stable/cypher-parameters.html#_create_multiple_nodes_with_properties
and: http://neo4j.com/docs/stable/query-set.html#set-adding-properties-from-maps
this provides significant speed up for hundreds of nodes

**add "lazy" ID only query results**
significant (seconds) speed up for hundreds of nodes where property values are not required for further operations

**cache all most used `defined_properties()`**
this method is called multiple times for each node class `init()`, this provides additional optimization when inflating nodes.


