### PR TITLE
Add "db_property" as parameter to Property.

### DIFF
--- a/doc/source/properties.rst
+++ b/doc/source/properties.rst
@@ -57,3 +57,21 @@ Allows aliasing to other properties can be useful to provide 'magic' behaviour, 
         name = AliasProperty(to='full_name')
 
     Person.nodes.filter(name='Jim') # just works
+    
+Independent database property name
+================================
+
+You can specify an independent property name with 'db_property', which is used on database level. It behaves like Django's 'db_column'.
+This is useful for e.g. hiding graph properties behind a python property::
+
+    class Person(StructuredNode):
+        name_ = StringProperty(db_property='name')
+        
+        @property
+        def name(self):
+            return self.name_.lower() if self.name_ else None
+
+        @name.setter
+        def name(self, value):
+            self.name_ = value
+

--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -162,7 +162,10 @@ def process_filter_args(cls, kwargs):
             else:
                 deflated_value = property_obj.deflate(value)
 
-        output[prop] = (operator, deflated_value)
+        # map property to correct property name in the database
+        db_property = cls.defined_properties(rels=False)[prop].db_property or prop
+
+        output[db_property] = (operator, deflated_value)
 
     return output
 

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -187,7 +187,7 @@ def test_independent_property_name():
     results, meta = db.cypher_query("MATCH (n:TestNode) RETURN n")
     assert results[0][0].properties['name'] == "jim"
 
-    assert not results[0][0].properties.has_key('name_')
+    assert not 'name_' in results[0][0].properties
     assert not hasattr(x, 'name')
     assert hasattr(x, 'name_')
     assert TestNode.nodes.filter(name_="jim").all()[0].name_ == x.name_

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -1,7 +1,7 @@
 from neomodel.properties import (IntegerProperty, DateTimeProperty,
     DateProperty, StringProperty, JSONProperty)
 from neomodel.exception import InflateError, DeflateError
-from neomodel import StructuredNode
+from neomodel import StructuredNode, db
 from pytz import timezone
 from datetime import datetime, date
 
@@ -174,3 +174,24 @@ def test_default_valude_callable_type():
     assert x.uid == '123'
     x.refresh()
     assert x.uid == '123'
+
+
+def test_independent_property_name():
+    class TestNode(StructuredNode):
+        name_ = StringProperty(db_property="name")
+    x = TestNode()
+    x.name_ = "jim"
+    x.save()
+
+    # check database property name on low level
+    results, meta = db.cypher_query("MATCH (n:TestNode) RETURN n")
+    assert results[0][0].properties['name'] == "jim"
+
+    assert not results[0][0].properties.has_key('name_')
+    assert not hasattr(x, 'name')
+    assert hasattr(x, 'name_')
+    assert TestNode.nodes.filter(name_="jim").all()[0].name_ == x.name_
+    assert TestNode.nodes.get(name_="jim").name_ == x.name_
+
+    # delete node afterwards
+    x.delete()


### PR DESCRIPTION
	You are now able to use different names for the property in the database and the python node attribute.
	This is quite useful, for "hiding" the property behind a "python property" subsequently. So you don't need to rename you database fields.
	For example renaming the property "name" to "name_" and adding a "python @property" "name" afterwards.
	Usages:
		name_ = StringProperty(db_property="name")
		name = StringProperty(db_property="full_name")