### PR TITLE
Bugfix empty filter append

### DIFF
--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -371,7 +371,8 @@ class NodeSet(BaseSet):
 
     def get(self, **kwargs):
         output = process_filter_args(self.source_class, kwargs)
-        self.filters.append(output)
+		if output:
+			self.filters.append(output)
         self.limit = 2
         result = self.query_cls(self).build_ast()._execute()
         if len(result) > 1:
@@ -383,12 +384,14 @@ class NodeSet(BaseSet):
 
     def filter(self, **kwargs):
         output = process_filter_args(self.source_class, kwargs)
-        self.filters.append(output)
+		if output:
+			self.filters.append(output)
         return self
 
     def exclude(self, **kwargs):
         output = process_filter_args(self.source_class, kwargs)
-        self.filters.append({'__NOT__': output})
+		if output:
+			self.filters.append({'__NOT__': output})
         return self
 
     def has(self, **kwargs):
@@ -457,7 +460,8 @@ class Traversal(BaseSet):
         if 'model' not in self.definition:
             raise ValueError("match() only available on relationships with a model")
         if kwargs:
-            self.filters.append(process_filter_args(self.definition['model'], kwargs))
+			output = process_filter_args(self.definition['model'], kwargs) 
+            self.filters.append(output)
         return self
 
     def _in_node_set(self):

--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -371,8 +371,8 @@ class NodeSet(BaseSet):
 
     def get(self, **kwargs):
         output = process_filter_args(self.source_class, kwargs)
-		if output:
-			self.filters.append(output)
+        if output:
+            self.filters.append(output)
         self.limit = 2
         result = self.query_cls(self).build_ast()._execute()
         if len(result) > 1:
@@ -384,14 +384,14 @@ class NodeSet(BaseSet):
 
     def filter(self, **kwargs):
         output = process_filter_args(self.source_class, kwargs)
-		if output:
-			self.filters.append(output)
+        if output:
+            self.filters.append(output)
         return self
 
     def exclude(self, **kwargs):
         output = process_filter_args(self.source_class, kwargs)
-		if output:
-			self.filters.append({'__NOT__': output})
+        if output:
+            self.filters.append({'__NOT__': output})
         return self
 
     def has(self, **kwargs):
@@ -460,8 +460,9 @@ class Traversal(BaseSet):
         if 'model' not in self.definition:
             raise ValueError("match() only available on relationships with a model")
         if kwargs:
-			output = process_filter_args(self.definition['model'], kwargs) 
-            self.filters.append(output)
+            output = process_filter_args(self.definition['model'], kwargs) 
+            if output:
+                self.filters.append(output)
         return self
 
     def _in_node_set(self):


### PR DESCRIPTION
Don't append empty filters to filters list. Otherwise this leads to self.filters not being evaluated as false leading to empty where statements in cypher query