### PR TITLE
python3: use .items() instead of deprecated .iteritems()

### DIFF
--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -44,7 +44,7 @@ def rel_helper(lhs, rhs, ident=None, relation_type=None, direction=None, relatio
 
     if relation_properties:
         rel_props = ' {{{0}}}'.format(', '.join(
-            ['{}: {}'.format(key, value) for key, value in relation_properties.iteritems()]))
+            ['{}: {}'.format(key, value) for key, value in relation_properties.items()]))
 
     # direct, relation_type=None is unspecified, relation_type
     if relation_type is None:


### PR DESCRIPTION
* Makes the library python 3 compatible, without this change, the error 
  ```Error “ 'dict' object has no attribute 'iteritems' ”``` when trying to add properties
  to a relation.