### PR TITLE
Encrypted connections parameter configurable

### DIFF
--- a/neomodel/config.py
+++ b/neomodel/config.py
@@ -1,3 +1,4 @@
 AUTO_INSTALL_LABELS = True
 DATABASE_URL = 'bolt://neo4j:neo4j@localhost:7687'
 FORCE_TIMEZONE = False
+ENCRYPTED_CONNECTION = True

--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -45,6 +45,8 @@ class Database(local):
         self._pid = None
 
     def set_connection(self, url):
+        self.encrypted = config.ENCRYPTED_CONNECTION
+
         self.url = url
         u = urlparse(url)
 
@@ -56,7 +58,7 @@ class Database(local):
                              " got {}".format(url))
 
         self.driver = GraphDatabase.driver('bolt://' + hostname,
-                                           auth=basic_auth(username, password))
+                                           auth=basic_auth(username, password), encrypted=self.encrypted)
         self.refresh_connection()
 
     @ensure_connection


### PR DESCRIPTION
This change makes the encrypted parameter for  the driver connection configurable (by default is set to True, that means that all connections are encrypted):

`GraphDatabase.driver('bolt://' + hostname, auth=basic_auth(username, password), encrypted=self.encrypted)`

This is useful in case that you want to have multiple neo4j instances and access them without having problems because of the checking of '~/.neo4j/known_hosts' certificate.

This is a common situation in a development environment as described in the Neo4j documentation in section [4.3.2.1. Encryption and authentication](https://neo4j.com/docs/developer-manual/current/drivers/configure-connect/).