### PR TITLE
Remove START and node() from cypher query build

### DIFF
--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -362,8 +362,17 @@ class QueryBuilder(object):
         query = ''
 
         if 'start' in self._ast:
-            query += 'START '
-            query += ', '.join(self._ast['start'])
+            initial_match = {'match': [], 'where': [], 'with': []}
+
+            for i in self._ast['start']:
+                r = i.split(' = ')
+                initial_match['match'].append('(%s)' % r[0])
+                initial_match['where'].append('id(%s)=%s' % (r[0], r[1].replace('node(','').replace(')','')))
+                initial_match['with'].append(r[0])
+
+            query += 'MATCH %s WHERE %s WITH %s' % (
+                ','.join(initial_match['match']), ' and '.join(initial_match['where']), ','.join(initial_match['with'])
+            )
 
         query += ' MATCH '
         query += ', '.join(['({})'.format(i) for i in self._ast['match']])


### PR DESCRIPTION
Neo4j v3.x does not support either START or node() therefore breaking relationship traversals, (e.g. node1.test_rel.all()) raising the exception "Internal error - should have used fall back to execute query, but something went horribly wrong" within Neo4j itself.

This fix should be like for like functionality, replace the START part of the query with the format "MATCH () WHERE id()= WITH ".