### PR TITLE
Test for model is None in Traversal.match()

### DIFF
--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -652,7 +652,7 @@ class Traversal(BaseSet):
         :param kwargs: see `NodeSet.filter()` for syntax
         :return: self
         """
-        if 'model' not in self.definition:
+        if 'model' not in self.definition or self.definition['model'] is None:
             raise ValueError("match() only available on relationships with a model")
         if kwargs:
             output = process_filter_args(self.definition['model'], kwargs) 

--- a/neomodel/match.py
+++ b/neomodel/match.py
@@ -652,9 +652,9 @@ class Traversal(BaseSet):
         :param kwargs: see `NodeSet.filter()` for syntax
         :return: self
         """
-        if 'model' not in self.definition or self.definition['model'] is None:
-            raise ValueError("match() only available on relationships with a model")
         if kwargs:
+            if 'model' not in self.definition or self.definition['model'] is None:
+                raise ValueError("match() with filter only available on relationships with a model")            
             output = process_filter_args(self.definition['model'], kwargs) 
             if output:
                 self.filters.append(output)


### PR DESCRIPTION
Since `RelationshipTo` and `RelationshipFrom` both set model to None in their constructors, the test needs to be for `model is None` not just for the `'model'` key being missing.