### PR TITLE
Add feature for removing constraints and indexes from schema

### DIFF
--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -67,6 +67,14 @@ Neomodel provides a script to automate this::
 
 It is important to execute this after altering the schema. Keep an eye on the number of classes it detects each time.
 
+Remove existing constraints and indexes
+=======================================
+For deleting all existing constraints and indexes from database, neomodel provides a script to automate this::
+
+    $ neomodel_remove_labels --db bolt://neo4j:neo4j@localhost:7687
+
+After executing, it will print all indexes and constraints it has deleted.
+
 Create, Save, Delete
 ====================
 

--- a/scripts/neomodel_remove_labels
+++ b/scripts/neomodel_remove_labels
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+from __future__ import print_function
+from os import environ
+from argparse import ArgumentParser
+
+from neomodel import db, remove_all_labels
+
+
+def main():
+    parser = ArgumentParser(
+        description='''
+        Drop all indexes and constraints on labels from schema in Neo4j database.
+
+        Database credentials can be set by the environment variable NEO4J_BOLT_URL.
+        ''')
+
+    parser.add_argument(
+        '--db', metavar='bolt://neo4j:neo4j@localhost:7687', dest='neo4j_bolt_url', type=str, default='',
+        help='address of your neo4j database'
+    )
+
+    args = parser.parse_args()
+
+    bolt_url = args.neo4j_bolt_url
+    if len(bolt_url) == 0:
+        bolt_url = environ.get('NEO4J_BOLT_URL', 'bolt://neo4j:neo4j@localhost:7687')
+
+    # Connect after to override any code in the module that may set the connection
+    print('Connecting to {}\n'.format(bolt_url))
+    db.set_connection(bolt_url)
+
+    remove_all_labels()
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     license='MIT',
     packages=find_packages(exclude=('tests',)),
     keywords='graph neo4j ORM OGM',
-    scripts=['scripts/neomodel_install_labels'],
+    scripts=['scripts/neomodel_install_labels', 'scripts/neomodel_remove_labels'],
     tests_require=['nose==1.3.7'],
     test_suite='nose.collector',
     install_requires=['neo4j-driver==1.2.1', 'pytz>=2016'],

--- a/test/test_label_drop.py
+++ b/test/test_label_drop.py
@@ -1,0 +1,35 @@
+from neomodel import StructuredNode, StringProperty, config
+from neomodel.core import db, remove_all_labels
+from neo4j.exceptions import ClientError
+
+config.AUTO_INSTALL_LABELS = True
+
+
+class ConstraintAndIndex(StructuredNode):
+    name = StringProperty(unique_index=True)
+    last_name = StringProperty(index=True)
+
+
+def test_drop_labels():
+    constraints_before, meta = db.cypher_query("CALL db.constraints()")
+    indexes_before, meta = db.cypher_query("CALL db.indexes()")
+
+    assert len(constraints_before) > 0
+    assert len(indexes_before) > 0
+
+    remove_all_labels()
+
+    constraints, meta = db.cypher_query("CALL db.constraints()")
+    indexes, meta = db.cypher_query("CALL db.indexes()")
+
+    assert len(constraints) == 0
+    assert len(indexes) == 0
+
+    # Returning all old constraints and indexes
+    for constraint in constraints_before:
+        db.cypher_query('CREATE ' + constraint[0])
+    for index in indexes_before:
+        try:
+            db.cypher_query('CREATE ' + index[0])
+        except ClientError:
+            pass


### PR DESCRIPTION
This feature is supposed to add functionality similar to neomodel_install_labels, just instead of creating new indexes and constraints it removes all existing ones.
Code is modeled after install_labels example.
Test is also added that remove all indexes and constraints and then reinstall all removed again not to mess up with other tests.
This feature was missing because manually removing installed labels especially when there is a lot of them is tedious work. 