### PR TITLE
Fix None driver issue with service unavailable issue

### DIFF
--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -44,7 +44,6 @@ class Database(local):
         self._pid = None
 
     def set_connection(self, url):
-        self.url = url
         u = urlparse(url)
 
         if u.netloc.find('@') > -1 and (u.scheme == 'bolt' or u.scheme == 'bolt+routing'):
@@ -58,6 +57,7 @@ class Database(local):
                                            auth=basic_auth(username, password),
                                            encrypted=config.ENCRYPTED_CONNECTION,
                                            max_pool_size=config.MAX_POOL_SIZE)
+        self.url = url
         self._pid = os.getpid()
         self._active_transaction = None
 


### PR DESCRIPTION
### Condition
I setup the database url using this `config.DATABASE_URL = 'DATABASE URL'`. In the case where docker container for neo4j spins up but is not ready to accepts the connection and the application tries to connect to the db. The `ServiceUnavailable` exception will be raised. In that case, the `self.driver` value is still `None`, however, `self.url` is already set to the new url. When `ensure_connection` is called, it checks if the `self.url` exist and in this case, it does ! Therefore, it tries to proceed and it ran into the problem accessing `session()` function from a `None` object. The `db` will permanently in the state where it cannot operate.

### Solution
only set `self.url` upon successful server connection